### PR TITLE
Update 시퀀트 계산.md

### DIFF
--- a/src/wiki/시퀀트 계산.md
+++ b/src/wiki/시퀀트 계산.md
@@ -1,13 +1,10 @@
 ---
 title: 시퀀트 계산
 categories: ["연역 체계"]
+mathMethod: MathJax
 license: CC BY-SA 4.0
 ---
-시퀀트 계산(sequent calculus)은 연역 체계의 일종으로, [게르하르트 겐첸](게르하르트 겐첸)이 1934년 논문 「논리적 추론에 관한 연구」에서 [자연 연역](자연 연역) 체계와 함께 발표하였다.
-
-## 기본 발상
-
-시퀀트 계산은 시퀀트라는 독특한 논리적 오브젝트를 조작하는 계산 체계다. 따라서 조작 방식에 따라 다양한 시퀀트 계산이 존재한다. 이 문서는 특히, (i) 최초로 제시된 겐첸의 체계 $\textbf{LK}$와 $\textbf{LJ}$(=클레이니의 $\textbf{G}_{1}$), (ii) 그리고 클레이니의 $\textbf{G}_{3}$을 다룬다.
+시퀀트 계산(sequent calculus)은 연역 체계의 일종으로, [게르하르트 겐첸](게르하르트 겐첸)이 1934년 논문 「논리적 추론에 관한 연구」에서 [자연 연역](자연 연역) 체계와 함께 발표하였다. 시퀀트 계산에서는 시퀀트라는 수학적 객체를 조작한다. 따라서 조작 방식에 따라 다양한 시퀀트 계산이 존재한다. 이 문서는 특히, (i) 최초로 제시된 겐첸의 체계 $\textbf{LK}$와 $\textbf{LJ}$(=클레이니의 $\textbf{G}_{1}$), (ii) 그리고 클레이니의 $\textbf{G}_{3}$을 다룬다.
 
 ### 시퀀트
 
@@ -18,12 +15,12 @@ license: CC BY-SA 4.0
 > 1. 시퀀트 $(\Gamma, \Delta)$를 $(\Gamma \Rightarrow \Delta)$라고 쓴다. 문맥에 따라 괄호는 생략할 수 있다. 
 >
 > 2. $\Gamma$를 시퀀트의 **전건**(antecedent), $\Delta$를 시퀀트의 **후건**(succedent)이라 부른다. 
-> 3. 두 나열의 접합(concatenation) 연산을 쉼표($,$)로 표기하고, 개별 공식을 한 원소 나열로 간주한다. 따라서 $(\Gamma,\varphi,\Delta\Rightarrow \Lambda,\psi,\Theta)$ 꼴 표기가 가능하다.
+> 3. 나열의 접합(concatenation) 연산을 쉼표($,$)로 표기하고, 개별 공식을 한 원소 나열로 간주한다. 따라서 $(\Gamma,\varphi,\Delta\Rightarrow \Lambda,\psi,\Theta)$ 꼴 표기가 가능하다.
 > 4.  시퀀트의 전건이나 후건이 빈 나열일 경우, 공백으로 표기한다($(\Rightarrow \Delta)$ 또는 $(\Gamma \Rightarrow)$).
 
+시퀀트 $\varphi_1,\cdots,\varphi_n\Rightarrow\psi_1,\cdots,\psi_m$의 의미는, 문장 $(\varphi_1\wedge\cdots\wedge\varphi_n)\rightarrow (\psi_1\vee\cdots\vee\psi_m)$의 의미와 같다고 이해할 수 있다. 따라서, 한 시퀀트가 옳다(correct)는 것은 대응하는 문장이 같은 조건 하에서 참임과 같다고 이해할 수 있다. 
 
-
-### 시퀀트 계산 개요 
+### 시퀀트 계산 개요
 
 논리 체계는 가정 공식들로부터 하나의 결론 공식을 유도한다. 증명은 유도과정의 명세다. 그래서 증명은 다수의 단말 노드(가정)로부터 루트 노드(결론)를 향해 수렴하는 트리 구조를 갖는다. 시퀀트 계산은 증명 트리의 공식 자리에 시퀀트를 놓는다. 그래서 마찬가지로 트리 구조를 갖는다. $n$개의 가정 시퀀트 $\Gamma_1 \Rightarrow \Delta_1, \cdots, \Gamma_n \Rightarrow \Delta_n$로부터 결론 $\Gamma'\Rightarrow \Delta'$를 도출하는 시퀀트 계산 규칙이 사용될 때, 다음으로 표기한다.
 $$
@@ -36,29 +33,9 @@ $$
 \end{prooftree}
 $$
 
-> **용어법:** 개별 시퀀트 계산 규칙에서, 
->
-> 1. 가로선 밑의 시퀀트를 **아래 시퀀트**(lower sequent)라고 부르고, 위의 시퀀트를 **위 시퀀트**(upper sequent)라고 부른다.
-> 2. 위 시퀀트에 나타나지 않는 공식이 규칙을 사용함으로써 아래 시퀀트에 새로 나타나면, 그 공식을 규칙의 **주공식**(principal formula)이라고 부른다.
-> 3. 주공식의 진부분공식이 위 시퀀트에 나타나는 것이 규칙의 성립 조건이면, 그 진부분공식들을 **변공식**(side formula)이라고 부른다.
-> 4. 위 시퀀트에 나타난 공식이 규칙을 사용함으로써 아래 시퀀트에서는 제거된다면, 그 공식을 규칙의 **컷 공식**(cut formula)라고 부른다.
-> 5. 규칙을 통해 변경되지 않는 공식을 **여분공식**(extra formula)이라고 부른다.
+시퀀트 계산의 추론 규칙은 귀결 관계의 전건과 후건의 조작으로 이해할 수 있다. 편의상 후건이 문장 하나 뿐이라고 생각하자. 그러면 시퀀트 $(\Gamma \Rightarrow \varphi)$를 귀결 관계로 이해할 수 있다.
 
-예를 들어, 다음 규칙을 보자.
-$$
-\begin{prooftree}
-\AxiomC{ $\Gamma_1\Rightarrow \Delta_1, A$ }
-\AxiomC{ $B, \Gamma_2\Rightarrow \Delta_2$ }
-\RightLabel{ $\rightarrow_{R}$ }
-\BinaryInfC{ $(A\rightarrow B), \Gamma_1, \Gamma_2 \Rightarrow \Delta_1,\Delta_2$ }
-\end{prooftree}
-$$
-
-위 규칙에서, (i) $(A\rightarrow B)$는 규칙의 주공식이다. (ii) $A, B$는 규칙의 변공식이다. $\Gamma_i, \Delta_i$에 나타나는 문장은 여분공식이다.
-
-시퀀트 계산에서, 시퀀트가 갖는 의미와 규칙의 역할을 직관적으로 이해하기는 어렵다. 편의상, 후건이 문장 하나 뿐이라고 생각하자. 그러면 시퀀트 $(\Gamma \Rightarrow \varphi)$는 귀결 관계 내지는 도출가능성 관계의 일종으로 이해할 수 있다. 이렇게 이해한다면, 시퀀트 계산은 곧 도출가능성 관계의 조작이다.
-
-증명구조의 성격을 이해하면, 시퀀트를 사용하는 이유에 대해 더 명확하게 이해할 수 있다. 통상 자연 연역에서는 가정의 제거(discharge)를 통하여 함축 연결사 $\rightarrow$를 도입하는 규칙을 사용한다. 이 때, 우리는 (i) 특정 함축문을 결론에 도입하고, (ii)증명을 역순으로 거슬러 올라가며 함축문의 전건에 해당하는 단말 노드에 마킹한다. 예컨대, 다음과 같은 의사증명 트리를 보자.
+증명구조의 성격을 이해하면, 문장 대신 시퀀트를 조작 대상으로 간주하는 기본 발상을 이해할 수 있다. 이를 자연 연역의 함축 도입 규칙($\rightarrow^{+}$)의 사례를 통해 알아보자.
 $$
 \begin{prooftree}
 \AxiomC{ $[A]^{1}$ }
@@ -79,7 +56,7 @@ $$
 \UnaryInfC{ $A\rightarrow B$ }
 \end{prooftree}
 $$
-이 증명 트리에서 $A\rightarrow B$를 도출해내기 위해, 우리는 증명을 거슬러 올라가 단말에 있는 $A$를 제거해야 한다. 즉, 개별 문장을 증명하려 할 때마다, $\rightarrow^{+}$ 규칙이 사용되면, 도출을 잠시 중단하고 증명구조 전체를 탐색하여 마킹해야 한다. 그러므로, $\rightarrow^{+}$ 규칙은 **맥락 의존적**(context-sensitive)인 규칙이다. 이 규칙은 만약 맥락이 존재한다면 추론을 통해 맥락을 변형한다. 반면 시퀀트 계산은 맥락 의존성을 전건에 명세함으로써 상황을 더 명확하게 표현할 수 있다. 그래서 $\textbf{LK}$ 증명에서는 규칙 $\rightarrow^{+}$를 사용하는 자연 연역 증명을 $\rightarrow_{R}$ 규칙으로 간단히 탈맥락화할 수 있다.
+이 증명 트리에서 $A\rightarrow B$를 도출해내기 위해, 단말에 있는 $A$에 첨수 $1$로 마킹해야 한다($[A]^{1}$). 즉, 개별 문장을 증명하려 할 때마다, $\rightarrow^{+}$ 규칙이 사용되면, 증명구조 전체를 역순으로 탐색하여, 맥락이 갖는 정보를 변경($A$에 $1$로 마킹)한다. 그러므로, $\rightarrow^{+}$ 규칙은 **맥락 의존적**(context-sensitive)인 규칙이다. 이 규칙은 만약 맥락이 존재한다면 추론을 통해 맥락을 변형한다. 반면 시퀀트 계산은 맥락 의존성을 전건에 명세함으로써, 증명 도중 맥락이 어떻게 변형되었는지를 한 시퀀트 내에서 표현할 수 있다. 그래서, 규칙 $\rightarrow^{+}$를 사용하는 자연 연역 증명을 $\textbf{LK}$ 증명의 $\rightarrow_{R}$ 규칙의 사용 사례로 간주할 수 있다.
 $$
 \begin{prooftree}
 \AxiomC{ $\Gamma_1, \Gamma_2, A\Rightarrow B$ }
@@ -87,9 +64,9 @@ $$
 \UnaryInfC{ $\Gamma_1, \Gamma_2\Rightarrow A\rightarrow B$ }
 \end{prooftree}
 $$
-이 시퀀트 계산 규칙에서, 우리가 보이는 것은 $A\rightarrow B$를 전제로부터 증명할 수 있음을 보이는 것이다. 그런데, 자연 연역 증명에서와 달리, 증명의 제반 맥락에 대한 정보가 시퀀트의 전건에 모두 속해 있으므로, 이 계산법에서는 시퀀트 증명 구조 전체를 기억하지 않으면서, 개별 시퀀트를 조작하거나 병합하는 방식으로 풀 수 있도록 증명 문제를 변형한다.
+이 시퀀트 계산 규칙에서, 우리가 보이는 것은 $A\rightarrow B$를 전제로부터 증명할 수 있음을 보이는 것이다. 그런데, 자연 연역 증명에서와 달리, 증명의 제반 맥락에 대한 정보가 시퀀트의 전건에 모두 속해 있으므로, 이 계산법에서는 시퀀트 증명 구조 전체를 기억하지 않고, 개별 시퀀트를 조작하거나 병합하는 방식으로 풀 수 있도록 증명 문제를 변형한다.
 
-한 가지 더 주목할 점은, 시퀀트 계산에서, 가정에서 결론을 향해 추론이 이루어질 때, 몇 가지 규칙을 제외하면, 나머지 규칙은 모두 가정 시퀀트들에 나타나는 공식들과 결론 시퀀트에 나타나는 공식의 부분공식을 모두 공유한다. (방금 든 $\rightarrow_{R}$의 예시에서도, 규칙 위쪽 시퀀트와 규칙 아래쪽 시퀀트는 모두, 공식 $\Gamma_1, \Gamma_2, A, B$를 공유한다. 이 공식을 해석하지 않고 단순히 연결사로 붙이고 떼는 것만으로 한 추론을 완성할 수 있다.) 위 시퀀트의 각 공식에 나타나는 연결사들은, 아래 시퀀트를 산출하기 위해 어떤 규칙을 사용해야 하는지 결정하고, 역도 성립한다. 따라서, 시퀀트 증명 트리의 위쪽이 일부 비어있을 때, 아래쪽을 사용하여 가정을 재구성할 수 있다. 이러한 방식의 증명을 시퀀트 계산에서의 **분석적 증명**(analytic proof)이라고 부른다. 이 역순 추적 방법으로 시퀀트가 아니라 개별 논리적 공식도 증명할 수 있을 것이다. 즉, 시퀀트 $(\Rightarrow \varphi)$를 루트 노드로 삼는 시퀀트 계산 증명이 존재하는지를 역순으로 검증함으로써, $\vdash \varphi$인지를 확인할 수 있다. 그러나, 몇 가지 규칙은 이와 같은 가역성을 갖지 않는다. 예를 들면 다음 규칙을 보자.
+한 가지 더 주목할 점은, 시퀀트 계산에서, 가정에서 결론을 향해 추론이 이루어질 때, 몇 가지 규칙을 제외하면, 나머지 규칙은 모두 가정 시퀀트들에 나타나는 공식들과 결론 시퀀트에 나타나는 공식의 부분공식을 모두 공유한다. (방금 든 $\rightarrow_{R}$의 예시에서, 규칙 위쪽 시퀀트와 규칙 아래쪽 시퀀트는 모두, 공식 $\Gamma_1, \Gamma_2, A, B$를 공유한다.) 위 시퀀트의 각 공식에 나타나는 연결사들은, 아래 시퀀트를 산출하기 위해 어떤 규칙을 사용해야 하는지 결정하고, 역도 성립한다. 따라서, 시퀀트 증명 트리의 위쪽이 일부 비어있을 때, 아래쪽을 사용하여 가정을 재구성할 수 있다. 이러한 방식의 증명을 시퀀트 계산에서의 **분석적 증명**(analytic proof)이라고 부른다. 반면 다른 규칙은 분석적 증명에 사용하기에 적합하지 않다. 예를 들면 다음 규칙을 보자.
 $$
 \begin{prooftree}
 \AxiomC{ $\Gamma_1\Rightarrow \Delta_1, B$ }
@@ -100,25 +77,22 @@ $$
 $$
 
 
-편의상 $(\Delta_1, \Delta_2)$가 한 문장 나열 $\varphi$라고 하면 이해가 더 쉽다. 이 규칙에서 위쪽 두 시퀀트에 모두 나타나는 공식 $B$는 아래 시퀀트에서 사라진다. 그래서 만약 아래 시퀀트가 먼저 주어졌을 때, 위 시퀀트를 역순으로 알아내야 한다면, $B$가 어떤 공식인지 아래 시퀀트만 봐서는 알 방법이 없다. 만약 한 시퀀트 증명 체계에서, $\textrm{cut}$을 반드시 사용해야만 도달할 수 있는 증명이 있다면 어떨까? 그렇다면, 이 규칙을 사용하는 증명에 대해서는 아래 시퀀트로부터 효과적인 역순 재구성은 불가능하다(문장은 무한하므로). 그러므로, **분석적이지 않은 규칙들을 사용하지 않더라도 모든 시퀀트를 증명할 수 있음을 보이는 것**이 체계적인 증명 체계의 구성에 중요한 요소를 갖게 된다. 겐첸에 따르면, 상단의 컷 규칙은 없더라도 체계의 증명능력에 효과를 미치지 않는다. 즉, 컷 규칙은 부수적이다. 이것이 겐첸이 시퀀트 계산 체계 $\textbf{LK}$에 대해 보인 **컷-제거 정리**(cut-elimination, Gentzen's _Hauptsatz_)다.
+편의상 $(\Delta_1, \Delta_2)$가 한 문장 $\varphi$라고 하면 이해가 쉽다. 이 규칙에서 위쪽 두 시퀀트에 모두 나타나는 공식 $B$는 아래 시퀀트에서 사라진다. 그래서 만약 아래 시퀀트가 먼저 주어졌을 때, 위 시퀀트를 역순으로 알아내야 한다면, $B$가 어떤 공식인지 아래 시퀀트만 봐서는 알 방법이 없다. 이 규칙을 사용해야 하는 증명에 대해서는, 아래 시퀀트로부터 효과적인 역순 재구성은 불가능하다(문장은 무한하므로). 그러므로, **분석적 규칙만 사용해 모든 시퀀트를 증명할 수 있는지**를 효과적인 증명 체계를 구성할 때 확인해야 한다. 겐첸에 따르면, 상단의 컷 규칙은 증명능력에 효과를 미치지 않는다. 즉, 시퀀트 계산에서 컷 규칙은 부수적이다. 이것이 겐첸이 시퀀트 계산 체계 $\textbf{LK}$에 대해 보인 **컷-제거 정리**(cut-elimination, Gentzen's _Hauptsatz_)다.
 
 ### 시스템 $\textbf{LK}$
 
 시스템 $\textbf{LK}$는 다음 규칙으로 이루어진다. 모든 문장 $A, B, \cdots$와 문장의 나열 $\Gamma, \Delta, \Lambda, \Theta, \cdots$에 대해,
 
 1. 공리:
-
 $$
 \begin{prooftree}
 \AxiomC{}
 \UnaryInfC{ $A\Rightarrow A$ }
 \end{prooftree}
 $$
-
 > **첨언:** 공리 규칙에는 임의의 문장 $A$ 대신 명제 변항 $p$를 대신 쓰는 경우가 있다. 이 경우, 더 일반적인 경우인 $(A\Rightarrow A)$의 증명 가능성은 $\textbf{LK}$에서는 귀납법으로 보일 수 있다.
 
 2. 세 그룹의 구조 규칙―약화(Weakening), 축약(Contraction), 교환(Exchange):
-
 $$
 \begin{prooftree}
 \AxiomC{$\Gamma\Rightarrow \Delta$}
@@ -132,7 +106,6 @@ $$
 \UnaryInfC{ $\Gamma\Rightarrow \Delta, A$ }
 \end{prooftree}
 $$
-
 $$
 \begin{prooftree}
 \AxiomC{$A, A, \Gamma\Rightarrow \Delta$}
@@ -146,7 +119,6 @@ $$
 \UnaryInfC{ $\Gamma\Rightarrow \Delta, A$ }
 \end{prooftree}
 $$
-
 $$
 \begin{prooftree}
 \AxiomC{$\Gamma, A, B, \Delta\Rightarrow \Theta$}
@@ -159,16 +131,7 @@ $$
 \UnaryInfC{ $\Gamma\Rightarrow\Delta, B, A, \Theta$ }
 \end{prooftree}
 $$
-
-> **첨언:** 
->
-> * 왼쪽 약화는 연언 중립원(neutral/identity constant) $\textbf{t}$ (또는 경우에 따라 $\top$)의 성질을 결정한다. 오른쪽 약화는 선언 중립원 $\textbf{f}$ (마찬가지로 또는 $\bot$)의 성질을 결정한다. 따라서 왼쪽 약화와 오른쪽 약화를 나누어서 각각 $i$, $o$로 다르게 부르기도 한다. 
-> * 축약 규칙에서도 엄격하게 $C_{L}$만을 축약이라 부르면서, $C_R$또는 그 듀얼을 밍글(mingle)이나 확장(expansion)으로 나누어 부르는 경우가 있다. 
-> * 교환 규칙도 치환(permutation)이나 가환(commutativity)로 부르는 경우도 있다.
-> * 각 구조 규칙은 문장 나열의 접합 연산이 빈 나열에 대한 모노이드를 형성한다는 점을 암묵적으로 전제한다. $W, C, E$ 규칙만 제거된 경우를 **완전람벡논리**(Full Lambek Logic, $\textbf{FL}$)라 부르고, 접합 연산의 결합법칙도 모두 제거되었을 때 **부분구조 논리**(substructural logic, $\textbf{SL}$)라 부른다.
-
 3. 컷:
-
 $$
 \begin{prooftree}
 \AxiomC{ $\Gamma\Rightarrow \Delta, B$ }
@@ -177,9 +140,7 @@ $$
 \BinaryInfC{ $\Gamma, \Lambda\Rightarrow \Delta,\Theta$ }
 \end{prooftree}
 $$
-
 4. 논리연결사 규칙:
-
 $$
 \begin{prooftree}
 \AxiomC{$A,\Gamma\Rightarrow \Delta$}
@@ -193,7 +154,6 @@ $$
 \UnaryInfC{ $(A\wedge B), \Gamma\Rightarrow \Delta$ }
 \end{prooftree}
 $$
-
 $$
 \begin{prooftree}
 \AxiomC{ $\Gamma\Rightarrow \Delta, A$ }
@@ -202,7 +162,6 @@ $$
 \BinaryInfC{ $\Gamma\Rightarrow \Delta, (A\wedge B)$ }
 \end{prooftree}
 $$
-
 $$
 \begin{prooftree}
 \AxiomC{ $A, \Gamma\Rightarrow \Delta$ }
@@ -211,7 +170,6 @@ $$
 \BinaryInfC{ $(A\lor B), \Gamma\Rightarrow \Delta$ }
 \end{prooftree}
 $$
-
 $$
 \begin{prooftree}
 \AxiomC{$\Gamma\Rightarrow \Delta, A$}
@@ -225,7 +183,6 @@ $$
 \UnaryInfC{ $\Gamma\Rightarrow \Delta, (A\vee B)$ }
 \end{prooftree}
 $$
-
 $$
 \begin{prooftree}
 \AxiomC{ $\Gamma\Rightarrow \Delta, A$ }
@@ -240,21 +197,19 @@ $$
 \UnaryInfC{ $\Gamma\Rightarrow (A\rightarrow B),\Delta$ }
 \end{prooftree}
 $$
-
 $$
 \begin{prooftree}
 \AxiomC{ $\Gamma\Rightarrow A, \Delta$ }
-\RightLabel{ $\rightarrow_{L}$ }
+\RightLabel{ $\neg{L}$ }
 \UnaryInfC{ $\Gamma, \neg A\Rightarrow \Delta$ }
 \end{prooftree}
 \kern 4em
 \begin{prooftree}
 \AxiomC{ $\Gamma, A\Rightarrow \Delta$ }
-\RightLabel{ $\rightarrow_{R}$ }
+\RightLabel{ $\neg{R}$ }
 \UnaryInfC{ $\Gamma\Rightarrow \neg A, \Delta$ }
 \end{prooftree}
 $$
-
 $$
 \begin{prooftree}
 \AxiomC{ $ A[\tau/x], \Gamma\Rightarrow \Delta$ }
@@ -268,7 +223,6 @@ $$
 \UnaryInfC{ $\Gamma\Rightarrow \Delta, \forall xA$ }
 \end{prooftree}
 $$
-
 $$
 \begin{prooftree}
 \AxiomC{ $ A[y/x], \Gamma\Rightarrow \Delta$ }
@@ -283,13 +237,63 @@ $$
 \end{prooftree}
 $$
 
-단, $\forall_\ast, \exists_\ast$ 규칙의 경우, $\tau$는 $A$에 나타난 $x$에 **자유롭게 치환할 수 있는 항이고**(term $\tau$ is free/substitutable for $x$ in $A$), $y$는 $A$에만 **고유한 변수**(eigenvariable)다.
+>  **용어법:** 개별 시퀀트 계산 규칙에서, 
+>
+> 1. 가로선 밑의 시퀀트를 **아래 시퀀트**(lower sequent)라고 부르고, 위의 시퀀트를 **위 시퀀트**(upper sequent)라 부른다.
+> 2. 위 시퀀트에 나타나지 않는 공식이 규칙을 사용함으로써 아래 시퀀트에 새로 나타나면, 그 공식을 규칙의 **주공식**(principal formula)이라 부른다.
+> 3. 주공식의 진부분공식이 위 시퀀트에 나타나는 것이 규칙의 성립 조건이면, 그 진부분공식들을 **변공식**(side formula)이라 부른다.
+> 4. 위 시퀀트에 나타난 공식이 규칙을 사용함으로써 아래 시퀀트에서는 제거된다면, 그 공식을 규칙의 **컷 공식**(cut formula)이라 부른다.
+> 5. 규칙을 통해 변경되지 않고 복사되는 공식을 **여분공식**(extra formula)이라 부른다.
 
-논리연결사 규칙의 명칭은 연결사를 시퀀트의 전건($L$)에 도입하는가 후건($R$)에 도입하는가에 따라 결정된다.
+예를 들어, $\rightarrow_{L}$ 규칙에서, (i) $(A\rightarrow B)$는 규칙의 주공식이다. (ii) $A, B$는 규칙의 변공식이다. $\Gamma, \Delta, \Lambda, \Theta$에 나타나는 문장은 여분공식이다.
+
+또한, $\forall, \exists$ 규칙의 경우, $\tau$는 $A$에 나타난 $x$에 **자유롭게 치환할 수 있는**(term $\tau$ is free/substitutable for $x$ in $A$) 항이어야만 하고, $y$는 $A$에만 **고유한 변수**(eigenvariable)여야 한다. 자유롭게 치환할 수 있음은 곧, $A$의 구속변수(bound variable)가 $\tau$에 나타나지 않음을 의미한다. 고유 변수임은 곧, 규칙의 아래 시퀀트에 $y$가 나타나지 않음을 의미한다. (즉, $y$는 $A$에만 나타나야 하고, $\Gamma,\Delta$ 그리고 주공식에는 나타나면 안 된다.)
+
+논리연결사 규칙의 명칭은 연결사를 시퀀트의 전건($L$)에 도입하는가 후건($R$)에 도입하는가에 따라 결정된다. 전건 규칙군과 후건 규칙군은, 각각 자연 연역 체계의 제거 규칙과 도입 규칙과 밀접한 연관을 갖는다. 이를 가장 쉽게 확인해보는 방법은, 여분공식 $\Gamma, \Delta$가 없는 경우를 생각해보는 것이다. $\wedge_{L1}$과 $\wedge_{R}$ 규칙을 각각 상응하는 자연 연역 규칙에 대응시켜 보겠다.
+$$
+\begin{prooftree}
+\AxiomC{$A\Rightarrow$}
+\RightLabel{$\wedge_{L1}$}
+\UnaryInfC{ $A\wedge B\Rightarrow$ }
+\end{prooftree}
+\mkern4em\begin{prooftree}
+\AxiomC{$\uparrow A\wedge B$}
+\RightLabel{$\wedge^{-}$}
+\UnaryInfC{ $\uparrow A$ }
+\end{prooftree}
+$$
+
+$$
+\begin{prooftree}
+\AxiomC{ $\Rightarrow A$ }
+\AxiomC{ $\Rightarrow B$ }
+\RightLabel{ $\wedge_{R}$ }
+\BinaryInfC{ $\Rightarrow (A\wedge B)$ }
+\end{prooftree}
+\kern4em
+\begin{prooftree}
+\AxiomC{ $\downarrow A$ }
+\AxiomC{ $\downarrow B$ }
+\RightLabel{ $\wedge^{+}$ }
+\BinaryInfC{ $\downarrow A\wedge B$ }
+\end{prooftree}
+$$
+
+$\wedge_{L1}$ 규칙은 전건에 $A\wedge B$를 도입한다. 이는 자연 연역 증명에서는 $A$로부터 상향 탐색하기 위해 $\wedge$ 제거 규칙이 사용된 경우 $A\wedge B$를 상향 탐색해야 함을 의미한다. 반면 $\wedge_{R}$ 규칙의 경우 자연 연역의 도입 규칙에 대응하는데, $A$와 $B$를 결론으로 갖는 증명 트리로부터 하향 탐색할 때 $\wedge$ 도입 규칙이 사용되면 $A\wedge B$ 라벨 노드를 하향 생성함을 지시한다. 즉, 시퀀트의 전건 규칙은 자연 연역에서 상향 탐색에 대응되고, 후건 규칙은 자연 연역의 하향 탐색에 대응된다.
+
+#### 보론: 구조 규칙의 우위
+
+상단의 구조 규칙은 람벡(J. Lambek)의 범주문법(categorical grammar)과 지라르(J.-Y. Girard)의 선형 논리(linear logic) 등에서는 부정된다. 이처럼, 시퀀트 계산 체계를 올바르게 정의했을 때, 구조 규칙이 일반적으로 성립하지 않는 논리군을 부분구조논리(substructural logic, $\textbf{SL}$)라 부른다. 오늘날 구조 규칙의 종류는 $W, C, E$뿐만 아니라 더 세분화되었다.
+
+* 왼쪽 약화는 연언 중립원(neutral/identity constant) $\textbf{t}/\overline{1}$ (또는, 경우에 따라 $\textbf{T}/\top$)의 성질을 결정한다. 오른쪽 약화는 선언 중립원 $\textbf{f}/\overline{0}$ (마찬가지로 또는 $\textbf{F}/\bot$)의 성질을 결정한다. 따라서 왼쪽 약화와 오른쪽 약화를 나누어 각각 $i$, $o$로 부르기도 한다. 
+* 축약 규칙에서도 엄격하게 $C_{L}$만을 축약($c$)이라 부르면서, $C_R$또는 그 듀얼을 밍글(mingle)이나 확장(expansion, $p$)으로 나누어 부르는 경우가 있다. 특히 연관 논리의 경우, 약화는 성립하지 않지만 축약은 성립하므로, 성립하는 축약의 종류와 강도에 따라 축약 규칙을 세분화한다. 
+* 교환 규칙($e$)도 치환(permutation)이나 가환(commutativity)으로 부르는 경우도 있다.
+* $W, C, E$ 규칙이 모두 제거된 경우를 **완전람벡논리**(Full Lambek Logic, $\textbf{FL}$)라 부른다. 반면 위 시퀀트 계산으로는 표현할 수 없는 규칙도 있다. 시퀀트는 전건과 후건이 문장의 나열임을 전제하고, 나열의 병합 조작은 결합법칙이 성립한다. (모노이드를 형성한다.) 그러나 결합법칙 구조규칙 $a$ 또한 제거될 수 있다. 이런 체계들도 부분구조논리지만, 완전람벡논리는 아니다. 역으로, 무제약 부분구조논리 $\textbf{SL}$에 결합법칙 $a$ 조건을 추가한 체계($\textbf{SL}_a$)를 완전람벡논리로 볼 수 있다. 
+* $e, a, c, p, i, o$ 구조 규칙은 모두 서로 독립적이다. 
 
 ### 시스템 $\textbf{LJ}$
 
-$\textbf{LJ}$는 모든 시퀀트의 후건이 단일 문장이라는 점을 빼면 $\textbf{LK}$와 동일하다. 그러나 $\textbf{LJ}$의 증명 능력은 $\textbf{LK}$보다 약하다. 왜냐하면, 후건이 단일 문장이라는 조건 때문에, (i) $W_{R}$은 제한적으로만 적용되고, $C_{R}$은 아예 적용할 수 없기 때문이다.
+$\textbf{LJ}$는 모든 시퀀트의 후건이 단일 문장이라는 점을 빼면 $\textbf{LK}$와 동일하다. 그러나 $\textbf{LJ}$의 증명 능력은 $\textbf{LK}$보다 약하다. 왜냐하면, 후건이 단일 문장이라는 조건 때문에, $W_{R}$은 제한적으로만 적용되고, $C_{R}$은 아예 적용할 수 없기 때문이다.
 
 ### 시스템 $\textbf{G}_3$: 비분석적 규칙의 제거, 논리연결사 규칙으로의 매입
 
@@ -302,9 +306,10 @@ $\textbf{LJ}$는 모든 시퀀트의 후건이 단일 문장이라는 점을 빼
 * Gentzen, G. (1935). Untersuchungen über das logische Schließen: I/II. Mathematische Zeitschrift, 35.
 * Gentzen, G. (1964). Investigations into logical deduction (M. Szabo, Trans.). In: _The Collected Papers of Gerhard Gentzen_.
 
-### 중요 연구서
+### 중요 연구서 및 교과서
 
-* Prawitz. D. (1965). _Natural Deudction: A Proof-Theoretical Study_.
+* Prawitz, D. (1965). _Natural Deudction: A Proof-Theoretical Study_.
+* Kleene, S. (1952). _Introduction to Metamathematics_.
 
 ### $\textbf{LK}$, $\textbf{LJ}$를 다루는 증명론 교과서
 


### PR DESCRIPTION
# 의견 반영 및 확인
1. 시퀀트 규칙에서의 역할에 따른 공식의 명칭을 설명하는 부분을 규칙 설명 이후로 옮기겠습니다.

2. 저는 맥락을 명시하는 자연 연역이 이미 시퀀트 계산이라고 보았습니다. 즉, NK 또한 시퀀트가 라벨인 트리 증명을 갖는다면 시퀀트 계산이라고 봐야 한다고 봅니다. 이 경우 개념 분류 문제가 아니라 어법상의 차이에 기인한 문제가 됩니다. 예컨대, "시퀀트 계산"이라는 용어를 엄격하게 LK의 변종에만 한정하는 용법에 따른다면, NK가 시퀀트 계산이 아닌 것은 맞습니다. 하지만, NK와 LK 모두 겐첸식 시스템이라는 하위 카테고리에 묶이고, 만약 겐첸식 시스템을, 시퀀트가 라벨인 트리 증명으로 표현한다면, 제가 "시퀀트 계산"이라고 말한 것은 "겐첸식 시스템"을 의미하고, "시퀀트 계산"은 LK에 대응될 것입니다.

3. 그것이 좋을 것 같습니다.

4. 사실 이 부분은 Pfenning 교수의 강의자료 이상의 서술을 제가 하기 어려워서 고민하고 있습니다. 제 문서에서, 중복되는 서술이나 장황한 예시를 제거하고 충분히 문단이 응축된다면, Pfenning 교수 강의자료를 요약하는 방식으로 더 서술하고 출처를 달 생각입니다.

# 질문에 대한 답변
1. 원래는 의도적으로 그런 설명을 피했습니다. 왜냐하면, 결합성이나 교환성이 부인되는 시퀀트 계산 체계에서는 고전적인 경우와 같은 식의 깔끔한 대응이 이루어지지 않기 때문입니다. (한 문장에 대응시키려면 전건의 문장을 후건으로 모두 내보내야 하는데, 결합과 교환이 부정될 정도로 약한 체계는 일반적인 연역 정리가 성립하지 않습니다. 그래서 basic deduction term같은 개념적 보조도구를 빌려야 합니다.) 그런데 지금 생각해보니, 이 문서의 내용 범위에서 굳이 그 일반적인 사례 때문에 직관적 이해를 숨길 필요가 없다고 생각합니다. 그래서 해당 방식의 시퀀트 의미 이해를 문단에 추가하겠습니다.

2. 이 부분은 제가 잘못 서술한 것이 맞습니다. 물론 SL은 주로 논의되는 구조 규칙을 모두 제거한 체계가 맞고 그것은 substructural logic의 약자입니다(하단 출처 1). 그러나 구조 규칙이 모두 제거된 경우만을 SL로 부른다는 서술은 잘못되었습니다. SL이라는 용어법은 Handbook of Mathematical Fuzzy Logic, Vol. 1, Chp.2 subsection 2.5에 따랐습니다. 다만, 경우에 따라 GL이나 다른 용어법이 있기는 합니다.